### PR TITLE
removes all links to broken sites

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,26 +48,21 @@
 
                 <p><a href="http://www.cocoaheads.org/us/NashvilleTennessee/">CocoaHeads</a></p>
 
-                <p><a href="http://www.meetup.com/Javascript-xTreme/">Javascript xTreme</a></p>
-
                 <p><a href="http://www.meetup.com/Data-Science-Nashville/">Data Science Nashville</a></p>
 
                 <p><a href="http://www.idofnashville.com">ID of Nashville</a></p>
 
                 <p><a href="https://plus.google.com/communities/113719429525008477069">NashDev Breakfast</a></p>
 
-                <p><a href="http://twitter.com/hacknocoast">Nashdiggity Hacknight</a></p>
                 <br /><strong>IRC (Freenode.net) #hacknocoast</strong></p>
 
                 <p><a href="http://nawsug.org">Nashville AWS</a></p>
                 <br /><strong>IRC (Freenode.net) #nawsug</strong></p>
 
-                <p><a href="http://nashvillebrigade.org">Nashville Brigade</a>
                 <br /><strong>IRC (Freenode.net) #nashbrigade</strong></p>
 
                 <p><a href="http://ggdnashville.com">Nashville Girl Geek Dinner</a></p>
 
-                <p><a href="http://nashdl.org">NashDL (Nashville Dynamic Languages)</a>
                 <br /><strong>IRC (Freenode.net) #nashdl</strong></p>
 
                 <p><a href="http://www.meetup.com/NashDL-Book-Club/">NashDL (Nashville Dynamic Languages) Book Club</a>
@@ -82,7 +77,6 @@
                 <p><a href="http://nashjs.org">NashJS</a>
                 <br /><strong>IRC (Freenode.net) #nashjs</strong></p>
 
-                <p><a href="http://meetup.com/nashkell">Nashkell</a>
                 <br /><strong>IRC (Freenode.net) #nashkell</strong></p>
 
                 <p><a href="http://www.meetup.com/Nashville-Linux-Users-Group/">Nashville Linux Users Group</a>
@@ -117,7 +111,6 @@
                 <p><a href="https://plus.google.com/communities/109037306990333691370">Vim User Group</a>
                 <br /><strong>IRC (Freenode.net) #nashvillevim</strong></p>
 
-                <p><a href="http://meetup.com/nashville-emacs-users-group">Nashville Emacs Users Group</a>
                 <br /><strong>IRC (Freenode.net) #nashville-emacs</strong></p>
 
                 <p><a href="http://www.meetup.com/Nashville-Lisp-Sync/">Nashville Lisp Sync</a>
@@ -126,20 +119,17 @@
             <td width="50%" valign="top">
                 <p>Conference/Initiatives</p>
 
-                <p><a href="http://co-op.nashvl.org">The Code Cooperative</a></p>
-
                 <p><a href="http://coderfaire.com">CoderFaire</a>
                 <br /><strong>IRC (Freenode.net) #coderfaire</strong></p>
 
-                <p><a href="http://hacknashville.com">HackNashville</a>
                 <br /><strong>IRC (Freenode.net) #hacknashville</strong></p>
-		
-		<p><a href="https://phreaknic.info">PhreakNIC</a>
-		<br /><strong>IRC (Freenode.net) #phreaknic</strong></p>
+
+                <p><a href="http://phreaknic.info">PhreakNIC</a>
+                <br /><strong>IRC (Freenode.net) #phreaknic</strong></p>
 
                 <p><a href="http://pytennessee.org">PyTennessee</a>
                 <br /><strong>IRC (Freenode.net) #pytn</strong></p>
-                
+
                 <p><a href="http://nodevember.org">Nodevember</a>
                 <br /><strong>IRC (Freenode.net) #nodevember</strong></p>
 


### PR DESCRIPTION
Address [issue #31](https://github.com/NCUSGL/ncusgl.github.com/issues/31), removing all broken links.

Left the IRC channels, in case folks wanted to hit those up.
